### PR TITLE
swap movements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@
 #    By: lpin <lpin@student.42.fr>                  +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/10/10 11:22:27 by lpin              #+#    #+#              #
-#    Updated: 2024/10/04 18:43:14 by lpin             ###   ########.fr        #
+#    Updated: 2024/10/10 20:29:05 by lpin             ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 CC = gcc
 CFLAGS = -Wall -Wextra -Werror -g #-fsanitize=address
 SRCS = src/push_swap.c src/orchestor.c src/check_entry.c src/check_list.c src/errors.c \
-		src/linked_list_utils.c src/ps_utils.c src/list_init.c
+		src/linked_list_utils.c src/ps_utils.c src/list_init.c src/swap.c src/sw_moves.c
 LIBFT = ./libft/libft.a
 OBJS = $(SRCS:.c=.o)
 

--- a/header/push_swap.h
+++ b/header/push_swap.h
@@ -6,7 +6,7 @@
 /*   By: lpin <lpin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/04 19:46:12 by lpin              #+#    #+#             */
-/*   Updated: 2024/10/06 17:42:08 by lpin             ###   ########.fr       */
+/*   Updated: 2024/10/10 20:27:38 by lpin             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,9 @@ typedef enum e_entry_error
 
 char	*ft_entry_orchestor(int argc, char **argv);
 
-void	ft_lst_orchestor(char *entry, t_ps *lst);
+t_ps	*ft_lst_orchestor(char *entry, t_ps *lst);
+
+void	ft_mov_orchestor(t_ps *stack);
 
 // errors.c
 
@@ -84,5 +86,19 @@ void	ft_repetead_number(t_ps **lst);
 long	ft_ps_atoi(char *s);
 
 void	ft_print_list(t_ps *lst);
+
+void	ft_find_bottom(t_ps **stack);
+
+// swap.c
+
+void	ft_swap(t_ps **stack);
+
+// sw_moves.c
+
+void	sa(t_ps **stack_a);
+
+void	sb(t_ps **stack_b);
+
+void	ss(t_ps **stack_a, t_ps **stack_b);
 
 #endif

--- a/src/orchestor.c
+++ b/src/orchestor.c
@@ -6,7 +6,7 @@
 /*   By: lpin <lpin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/26 20:34:02 by lpin              #+#    #+#             */
-/*   Updated: 2024/10/04 18:51:25 by lpin             ###   ########.fr       */
+/*   Updated: 2024/10/10 20:29:42 by lpin             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,9 +26,19 @@ char	*ft_entry_orchestor(int argc, char **argv)
 	return (aux);
 }
 
-void	ft_lst_orchestor(char *entry, t_ps *lst)
+t_ps	*ft_lst_orchestor(char *entry, t_ps *lst)
 {
 	ft_lst_init(entry, &lst);
-	ft_print_list(lst);
-	ft_ps_destroy(&lst);
+	return (lst);
+}
+
+void	ft_mov_orchestor(t_ps *stack)
+{
+	ft_printf("-------original-------\n");
+	ft_print_list(stack);
+	ft_printf("-------modified-------\n");
+	sb(&stack);
+	ft_print_list(stack);
+	ft_printf("----------------------\n");
+	ft_ps_destroy(&stack);
 }

--- a/src/ps_utils.c
+++ b/src/ps_utils.c
@@ -6,11 +6,23 @@
 /*   By: lpin <lpin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/29 18:54:22 by lpin              #+#    #+#             */
-/*   Updated: 2024/10/04 20:06:58 by lpin             ###   ########.fr       */
+/*   Updated: 2024/10/10 20:19:45 by lpin             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../header/push_swap.h"
+
+void	ft_find_bottom(t_ps **stack)
+{
+	t_ps	*aux;
+
+	aux = *stack;
+	if (!aux)
+		return ;
+	while (aux->tail != 1)
+		aux = aux->next;
+	*stack = aux;
+}
 
 void	ft_print_list(t_ps *lst)
 {

--- a/src/push_swap.c
+++ b/src/push_swap.c
@@ -6,7 +6,7 @@
 /*   By: lpin <lpin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/26 20:27:03 by lpin              #+#    #+#             */
-/*   Updated: 2024/10/04 18:40:09 by lpin             ###   ########.fr       */
+/*   Updated: 2024/10/10 20:00:59 by lpin             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@ int	main( int argc, char **argv)
 {
 	char	*entry;
 	t_ps	lst;
+	t_ps	*stack;
 
 	entry = NULL;
 	ft_memset(&lst, 0, sizeof(lst));
@@ -25,7 +26,8 @@ int	main( int argc, char **argv)
 	{
 		argv++ ;
 		entry = ft_entry_orchestor(argc, argv);
-		ft_lst_orchestor(entry, &lst);
+		stack = ft_lst_orchestor(entry, &lst);
+		ft_mov_orchestor(stack);
 	}
 	return (0);
 }


### PR DESCRIPTION
Implemented the swap operations for the stack, including the functions `sa`, `sb`, and `ss`, which operate at a higher level by calling the lower-level `swap` function to interchange the first two elements of a stack. Additionally, added the `ft_lst_orchestor` function to initialize the list from an entry. These changes establish a clear hierarchy of function calls, with the movement orchestrator capable of invoking sub-level functions that perform the actual swap operations.

 - sw_moves.c | -> swap.c